### PR TITLE
Migration - Jura

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,5 @@ metadata.json
 !input/sample_migration_import.csv
 
 *_wip*
+
+scripts/*/_output/*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
         "--ignore=E24,E265,E501,W504",
         "--verbose"
     ],
-    "python.pythonPath": "C:\\Users\\JulienMOURA\\.virtualenvs\\migrations-toolbelt-Ipnv7lTT\\Scripts\\python.exe",
+    "python.pythonPath": ".venv\\Scripts\\python.exe",
     "python.testing.pytestEnabled": true,
     "python.testing.pytestArgs": [
         "-c",

--- a/scripts/jura/delete_jura.py
+++ b/scripts/jura/delete_jura.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
             li_md_to_delete.append(metadata._id)
         else:
             pass
-
+    logger.debug("------- {} source metadatas listed gonna be backuped then deleted -------")
     # ################# BACKUP MDs THAT ARE GONNA BE DELETED #######################
     # instanciate backup manager
     backup_path = Path(r"./scripts/jura/_output/_backup")
@@ -109,7 +109,7 @@ if __name__ == "__main__":
         li_bound.append(amplitude * i)
     li_bound.append(len(li_md_to_delete))
 
-    logger.info("Starting backup for {} rounds".format(len(li_bound) - 1))
+    logger.info("------- Starting backup for {} rounds -------".format(len(li_bound) - 1))
     for i in range(len(li_bound) - 1):
         bound_inf = li_bound[i]
         bound_sup = li_bound[i + 1]
@@ -122,9 +122,8 @@ if __name__ == "__main__":
             logger.info("an error occured : {}".format(e))
 
     # ################# DELETE LISTED SRC MDs #######################
-
+    logger.debug("------- Starting to delete source metadatas -------")
     for md in li_md_to_delete:
         isogeo.metadata.delete(md)
 
     isogeo.close()
-

--- a/scripts/jura/delete_jura.py
+++ b/scripts/jura/delete_jura.py
@@ -1,0 +1,130 @@
+# -*- coding: UTF-8 -*-
+#! python3
+
+"""
+    Name:         Duplicate script for Jura data in 2019
+    Author:       Isogeo
+    Purpose:      Script using the migrations-toolbelt package to perform metadata migration.
+                Logs are willingly verbose.
+    Python:       3.7+
+"""
+
+# ##############################################################################
+# ########## Libraries #############
+
+# Standard Library
+import logging
+from logging.handlers import RotatingFileHandler
+from os import environ
+from pathlib import Path
+
+# 3rd party
+from dotenv import load_dotenv
+
+# Isogeo
+from isogeo_pysdk import Isogeo, IsogeoChecker, Metadata
+
+# submodules
+from isogeo_migrations_toolbelt import BackupManager
+
+
+# load .env file
+load_dotenv("jura.env", override=True)
+
+checker = IsogeoChecker()
+
+if __name__ == "__main__":
+    # logs
+    logger = logging.getLogger()
+    # ------------ Log & debug ----------------
+    logging.captureWarnings(True)
+    logger.setLevel(logging.INFO)
+    # logger.setLevel(logging.INFO)
+
+    log_format = logging.Formatter(
+        "%(asctime)s || %(levelname)s "
+        "|| %(module)s - %(lineno)d ||"
+        " %(funcName)s || %(message)s"
+    )
+
+    # debug to the file
+    log_file_handler = RotatingFileHandler(
+        Path("./scripts/jura/delete_jura.log"), "a", 5000000, 1
+    )
+    log_file_handler.setLevel(logging.INFO)
+    log_file_handler.setFormatter(log_format)
+
+    # info to the console
+    log_console_handler = logging.StreamHandler()
+    log_console_handler.setLevel(logging.INFO)
+    log_console_handler.setFormatter(log_format)
+
+    logger.addHandler(log_file_handler)
+    logger.addHandler(log_console_handler)
+
+    src_cat = environ.get("ISOGEO_CATALOG_SOURCE")
+    trg_cat = environ.get("ISOGEO_CATALOG_TARGET")
+
+    # ################# MAKE THE LIST OF SRC MD'S UUID TO DELETE #######################
+    # API client instanciation
+    isogeo = Isogeo(
+        client_id=environ.get("ISOGEO_API_USER_LEGACY_CLIENT_ID"),
+        client_secret=environ.get("ISOGEO_API_USER_LEGACY_CLIENT_SECRET"),
+        auto_refresh_url="{}/oauth/token".format(environ.get("ISOGEO_ID_URL")),
+        platform=environ.get("ISOGEO_PLATFORM", "qa"),
+        auth_mode="user_legacy",
+    )
+    isogeo.connect(
+        username=environ.get("ISOGEO_USER_NAME"),
+        password=environ.get("ISOGEO_USER_PASSWORD"),
+    )
+
+    src_md = isogeo.search(
+        group=environ.get("ISOGEO_ORIGIN_WORKGROUP"),
+        whole_results=True,
+        query="catalog:{}".format(src_cat),
+        include="all"
+    )
+
+    # listing
+    li_md_to_delete = []
+    for md in src_md.results:
+        metadata = Metadata.clean_attributes(md)
+        md_cat = [metadata.tags.get(tag) for tag in metadata.tags if tag.startswith("catalog:")]
+        if trg_cat not in md_cat:
+            li_md_to_delete.append(metadata._id)
+        else:
+            pass
+
+    # ################# BACKUP MDs THAT ARE GONNA BE DELETED #######################
+    # instanciate backup manager
+    backup_path = Path(r"./scripts/jura/_output/_backup")
+    backup_mng = BackupManager(api_client=isogeo, output_folder=backup_path)
+
+    # lauching backup
+    amplitude = 50
+    bound_range = int(len(li_md_to_delete) / amplitude)
+    li_bound = []
+    for i in range(bound_range + 1):
+        li_bound.append(amplitude * i)
+    li_bound.append(len(li_md_to_delete))
+
+    logger.info("Starting backup for {} rounds".format(len(li_bound) - 1))
+    for i in range(len(li_bound) - 1):
+        bound_inf = li_bound[i]
+        bound_sup = li_bound[i + 1]
+        logger.info("Round {} - backup from source metadata {} to {}".format(i + 1, bound_inf + 1, bound_sup))
+
+        search_parameters = {"query": None, "specific_md": tuple(li_md_to_delete[bound_inf:bound_sup])}
+        try:
+            backup_mng.metadata(search_params=search_parameters)
+        except Exception as e:
+            logger.info("an error occured : {}".format(e))
+
+    # ################# DELETE LISTED SRC MDs #######################
+
+    for md in li_md_to_delete:
+        isogeo.metadata.delete(md)
+
+    isogeo.close()
+

--- a/scripts/jura/delete_jura.py
+++ b/scripts/jura/delete_jura.py
@@ -17,6 +17,7 @@ import logging
 from logging.handlers import RotatingFileHandler
 from os import environ
 from pathlib import Path
+from time import sleep
 
 # 3rd party
 from dotenv import load_dotenv
@@ -49,7 +50,7 @@ if __name__ == "__main__":
 
     # debug to the file
     log_file_handler = RotatingFileHandler(
-        Path("./scripts/jura/delete_jura.log"), "a", 5000000, 1
+        Path("./scripts/jura/_logs/delete_jura.log"), "a", 5000000, 1
     )
     log_file_handler.setLevel(logging.INFO)
     log_file_handler.setFormatter(log_format)
@@ -95,7 +96,7 @@ if __name__ == "__main__":
             li_md_to_delete.append(metadata._id)
         else:
             pass
-    logger.debug("------- {} source metadatas listed gonna be backuped then deleted -------")
+    logger.info("------- {} source metadatas listed gonna be backuped then deleted -------".format(len(li_md_to_delete)))
     # ################# BACKUP MDs THAT ARE GONNA BE DELETED #######################
     # instanciate backup manager
     backup_path = Path(r"./scripts/jura/_output/_backup")
@@ -122,8 +123,14 @@ if __name__ == "__main__":
             logger.info("an error occured : {}".format(e))
 
     # ################# DELETE LISTED SRC MDs #######################
-    logger.debug("------- Starting to delete source metadatas -------")
+    logger.info("------- Starting to delete source metadatas -------")
     for md in li_md_to_delete:
+        count = li_md_to_delete.index(md) + 1
+        if (count % 50) == 0:
+            logger.info("Form {} to {} metadatas deleted ".format(count - 50, count))
+            sleep(2)
+        else:
+            pass
         isogeo.metadata.delete(md)
 
     isogeo.close()

--- a/scripts/jura/duplicate_jura.py
+++ b/scripts/jura/duplicate_jura.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 
     # debug to the file
     log_file_handler = RotatingFileHandler(
-        Path("./scripts/jura/duplicate_jura.log"), "a", 5000000, 1
+        Path("./scripts/jura/_logs/duplicate_jura.log"), "a", 5000000, 1
     )
     log_file_handler.setLevel(logging.INFO)
     log_file_handler.setFormatter(log_format)

--- a/scripts/jura/duplicate_jura.py
+++ b/scripts/jura/duplicate_jura.py
@@ -249,12 +249,12 @@ if __name__ == "__main__":
                 )
                 pass
             src_migrated = src_migrator.duplicate_into_other_group(
-                destination_workgroup_uuid=environ.get("ISOGEO_WORKGROUP_MIGRATION"),
+                destination_workgroup_uuid=environ.get("ISOGEO_MIGRATION_WORKGROUP"),
                 copymark_abstract=True,
                 copymark_title=True,
             )
             trg_migrated = trg_migrator.duplicate_into_other_group(
-                destination_workgroup_uuid=environ.get("ISOGEO_WORKGROUP_MIGRATION"),
+                destination_workgroup_uuid=environ.get("ISOGEO_MIGRATION_WORKGROUP"),
                 copymark_abstract=True,
                 copymark_title=True,
             )

--- a/scripts/jura/duplicate_jura.py
+++ b/scripts/jura/duplicate_jura.py
@@ -1,0 +1,286 @@
+# -*- coding: UTF-8 -*-
+#! python3
+
+"""
+    Name:         Duplicate script for Jura data in 2019
+    Author:       Isogeo
+    Purpose:      Script using the migrations-toolbelt package to perform metadata migration.
+                Logs are willingly verbose.
+    Python:       3.7+
+"""
+
+# ##############################################################################
+# ########## Libraries #############
+
+# Standard Library
+import csv
+import logging
+from logging.handlers import RotatingFileHandler
+from os import environ
+from pathlib import Path
+
+# 3rd party
+from dotenv import load_dotenv
+
+# Isogeo
+from isogeo_pysdk import Isogeo, IsogeoChecker
+
+# submodules
+from isogeo_migrations_toolbelt import MetadataDuplicator
+
+# load .env file
+load_dotenv(".env", override=True)
+
+checker = IsogeoChecker()
+
+if __name__ == "__main__":
+    # logs
+    logger = logging.getLogger()
+    # ------------ Log & debug ----------------
+    logging.captureWarnings(True)
+    logger.setLevel(logging.INFO)
+    # logger.setLevel(logging.INFO)
+
+    log_format = logging.Formatter(
+        "%(asctime)s || %(levelname)s "
+        "|| %(module)s - %(lineno)d ||"
+        " %(funcName)s || %(message)s"
+    )
+
+    # debug to the file
+    log_file_handler = RotatingFileHandler(
+        Path("./scripts/jura/duplicate_jura.log"), "a", 5000000, 1
+    )
+    log_file_handler.setLevel(logging.INFO)
+    log_file_handler.setFormatter(log_format)
+
+    # info to the console
+    log_console_handler = logging.StreamHandler()
+    log_console_handler.setLevel(logging.INFO)
+    log_console_handler.setFormatter(log_format)
+
+    logger.addHandler(log_file_handler)
+    logger.addHandler(log_console_handler)
+
+    logger.info("\n------------ DUPLICATING SESSION ------------")
+    logger.info("TESTING MAPPING TABLE")
+    # ############# CHECK MAPPING TABLE #############
+    # to store source metadata uuid, title and name that passe the tests
+    li_src_to_duplicate = []
+    # store all source uuid that appear in the mapping table
+    src_found = []
+    # to store target metadata uuid, title and name that passe the tests
+    li_trg_to_duplicate = []
+    # store all target uuid that appear in the mapping table
+    trg_found = []
+    # prepare csv reading
+    input_csv = Path(r"./scripts/jura/correspondances.csv")
+    fieldnames = [
+        "source_uuid",
+        "source_title",
+        "source_name",
+        "target_name",
+        "target_uuid",
+    ]
+    with input_csv.open() as csvfile:
+        reader = csv.DictReader(csvfile, delimiter=";", fieldnames=fieldnames)
+
+        row_num = 0
+        for row in reader:
+            row_num += 1
+            src_uuid = row.get("source_uuid")
+            src_title = row.get("source_title")
+            src_name = row.get("source_name")
+            trg_uuid = row.get("target_uuid")
+            trg_name = row.get("target_name")
+            # *=====* to duplicate only 1 on 10 sheets
+            if src_uuid != "source_uuid" and row_num % 25 == 0:
+                src_found.append(src_uuid)
+                trg_found.append(trg_uuid)
+                # check source UUID validity
+                if trg_uuid == "NR":
+                    logger.info("l.{} - there is no target".format(row_num))
+                elif not checker.check_is_uuid(src_uuid):
+                    logger.info(
+                        "l.{} - {} is not a regular UUID".format(row_num, src_uuid)
+                    )
+                # check if source UUID appears just one time in the field
+                elif li_src_to_duplicate.count(src_uuid) > 0:
+                    logger.info(
+                        "l.{} - {} already exist in the tab at line {}".format(
+                            row_num, src_uuid, str(src_found.index(src_uuid) + 1)
+                        )
+                    )
+                # if all check are passed : uuid, title and name of source metadata
+                # are stored into tuple and added to a list
+                else:
+                    # check target UUID validity
+                    if not checker.check_is_uuid(trg_uuid):
+                        logger.info(
+                            "l.{} -{} target UUID isn't valid".format(row_num, trg_uuid)
+                        )
+                    # check if target UUID appears just one time in the field
+                    elif li_trg_to_duplicate.count(trg_uuid) > 0:
+                        logger.info(
+                            "l.{} - {} target UUID already exist in the tab at line {}".format(
+                                row_num, trg_uuid, str(trg_found.index(trg_uuid) + 1)
+                            )
+                        )
+                    # check if target UUID is different from source UUID
+                    elif trg_uuid == src_uuid:
+                        logger.info(
+                            "l.{} - {} target and source UUID are the same".format(
+                                row_num, trg_uuid
+                            )
+                        )
+                    # if all check are passed : uuid, and name of target and source
+                    # metadata are stored into a tuple and added to a list
+                    else:
+                        to_duplicate = (src_uuid, src_title, src_name)
+                        li_src_to_duplicate.append(to_duplicate)
+                        to_duplicate = (trg_uuid, trg_name)
+                        li_trg_to_duplicate.append(to_duplicate)
+            else:
+                pass
+
+    # once each row have been test, the results of the checks are displayed in the log
+    expected_uuid_nb = len(src_found)
+    found_uuid_nbr = len(li_src_to_duplicate)
+    if found_uuid_nbr == expected_uuid_nb:
+        logger.info("--> All lines passed the check.")
+    else:
+        logger.error(
+            "--> {}/{} lines didn't passe the check.".format(
+                expected_uuid_nb - found_uuid_nbr, expected_uuid_nb
+            )
+        )
+    if len(set(li_src_to_duplicate)) == found_uuid_nbr:
+        logger.info("--> Each source uuid appears only once.")
+    else:
+        logger.error("--> There is some duplicate source uuid.")
+
+    found_uuid_nbr = len(li_trg_to_duplicate)
+    if len(set(li_trg_to_duplicate)) == found_uuid_nbr:
+        logger.info("--> Each target uuid appears only once.")
+    else:
+        logger.error("--> There is some duplicate target uuid.")
+
+    logger.info(
+        "DUPLICATING {} METADATAS INTO 'ISOGEO MIGRATIONS' WORKGROUP".format(
+            len(li_src_to_duplicate) * 2
+        )
+    )
+    # ############# DUPLICATING #############
+    # API client instanciation
+    isogeo = Isogeo(
+        client_id=environ.get("ISOGEO_API_USER_LEGACY_CLIENT_ID"),
+        client_secret=environ.get("ISOGEO_API_USER_LEGACY_CLIENT_SECRET"),
+        auto_refresh_url="{}/oauth/token".format(environ.get("ISOGEO_ID_URL")),
+        platform=environ.get("ISOGEO_PLATFORM", "qa"),
+        auth_mode="user_legacy",
+    )
+    isogeo.connect(
+        username=environ.get("ISOGEO_USER_NAME"),
+        password=environ.get("ISOGEO_USER_PASSWORD"),
+    )
+    # to build mapping table of 'Isogeo Migrations' workgroup
+    li_migrated = []
+    index = 0
+    for md in li_src_to_duplicate:
+        src_uuid = md[0]
+        src_title = md[1]
+        src_name = md[2]
+        trg_uuid = li_trg_to_duplicate[index][0]
+        trg_name = li_trg_to_duplicate[index][1]
+
+        # loading the metadata to duplicate from his UUID
+        src_migrator = MetadataDuplicator(
+            api_client=isogeo, source_metadata_uuid=src_uuid
+        )
+        src_loaded = src_migrator.metadata_source
+
+        trg_migrator = MetadataDuplicator(
+            api_client=isogeo, source_metadata_uuid=trg_uuid
+        )
+        trg_loaded = trg_migrator.metadata_source
+
+        # check if the metadata exists
+        if isinstance(src_loaded, tuple):
+            logger.info(
+                "{} - There is no accessible source metadata corresponding to this "
+                "uuid".format(src_uuid)
+            )
+            pass
+        elif isinstance(trg_loaded, tuple):
+            logger.info(
+                "{} - There is no accessible target metadata corresponding to this "
+                "uuid".format(trg_uuid)
+            )
+            pass
+        # checks metadata name and title indicated in the mapping table
+        # then, dupplicate the metadata
+        else:
+            if src_title == src_loaded._title:
+                pass
+            else:
+                logger.info(
+                    "{} - this metadata title is '{}' and not '{}'".format(
+                        src_uuid, src_loaded._title, src_title
+                    )
+                )
+                pass
+            if src_name == src_loaded._name:
+                pass
+            else:
+                logger.info(
+                    "{} - this metadata name is '{}' and not '{}'".format(
+                        src_uuid, src_loaded._name, src_name
+                    )
+                )
+                pass
+
+            if trg_name == src_loaded._name:
+                pass
+            else:
+                logger.info(
+                    "{} - this metadata name is '{}' and not '{}'".format(
+                        trg_uuid, src_loaded._name, trg_name
+                    )
+                )
+                pass
+            src_migrated = src_migrator.duplicate_into_other_group(
+                destination_workgroup_uuid=environ.get("ISOGEO_WORKGROUP_MIGRATION"),
+                copymark_abstract=True,
+                copymark_title=True,
+            )
+            trg_migrated = trg_migrator.duplicate_into_other_group(
+                destination_workgroup_uuid=environ.get("ISOGEO_WORKGROUP_MIGRATION"),
+                copymark_abstract=True,
+                copymark_title=True,
+            )
+            li_migrated.append(
+                [
+                    src_migrated._id,
+                    src_migrated.title,
+                    src_migrated.name,
+                    trg_migrated._id,
+                    trg_migrated.name,
+                ]
+            )
+            index += 1
+    isogeo.close()
+
+    csv_sample = Path(r"./scripts/jura/sample.csv")
+    with open(csv_sample, "w") as csvfile:
+        writer = csv.writer(csvfile, delimiter=";")
+        writer.writerow(
+            [
+                "source_uuid",
+                "source_title",
+                "source_name",
+                "target_uuid",
+                "target_name",
+            ]
+        )
+        for data in li_migrated:
+            writer.writerow(data)

--- a/scripts/jura/migration_jura.py
+++ b/scripts/jura/migration_jura.py
@@ -1,0 +1,268 @@
+# -*- coding: UTF-8 -*-
+#! python3
+
+"""
+    Name:         Migration script for Jura data in 2019
+    Author:       Isogeo
+    Purpose:      Script using the migrations-toolbelt package to perform metadata migration.
+                Logs are willingly verbose.
+    Python:       3.7+
+"""
+
+# ##############################################################################
+# ########## Libraries #############
+
+# Standard Library
+import csv
+import logging
+from logging.handlers import RotatingFileHandler
+from os import environ
+from pathlib import Path
+
+# 3rd party
+from dotenv import load_dotenv
+
+# Isogeo
+from isogeo_pysdk import (
+    Isogeo,
+    IsogeoChecker,
+    # ApiCatalog
+)
+
+# submodules
+from isogeo_migrations_toolbelt import MetadataDuplicator, BackupManager
+
+# load .env file
+load_dotenv(".env", override=True)
+
+checker = IsogeoChecker()
+
+if __name__ == "__main__":
+    # logs
+    logger = logging.getLogger()
+    # ------------ Log & debug ----------------
+    logging.captureWarnings(True)
+    logger.setLevel(logging.INFO)
+    # logger.setLevel(logging.INFO)
+
+    log_format = logging.Formatter(
+        "%(asctime)s || %(levelname)s "
+        "|| %(module)s - %(lineno)d ||"
+        " %(funcName)s || %(message)s"
+    )
+
+    # debug to the file
+    log_file_handler = RotatingFileHandler(
+        Path("./scripts/jura/migration_jura.log"), "a", 5000000, 1
+    )
+    log_file_handler.setLevel(logging.DEBUG)
+    log_file_handler.setFormatter(log_format)
+
+    # info to the console
+    log_console_handler = logging.StreamHandler()
+    log_console_handler.setLevel(logging.DEBUG)
+    log_console_handler.setFormatter(log_format)
+
+    logger.addHandler(log_file_handler)
+    logger.addHandler(log_console_handler)
+
+    logger.info("\n------------ MIGRATION SESSION ------------")
+    logger.info("TESTING MAPPING TABLE")
+    # ################# CHECK MAPPING TABLE and RETRIEVE UUID FROM IT #################
+    # to store source metadata uuid to backup
+    li_to_backup = []
+    # to store source metadata uuid, title and name that passe the tests
+    li_src_to_migrate = []
+    # store all source uuid that appear in the mapping table
+    src_found = []
+    # to store target metadata uuid, title and name that passe the tests
+    li_trg_to_migrate = []
+    # store all target uuid that appear in the mapping table
+    trg_found = []
+    # prepare csv reading
+    input_csv = Path(r"./scripts/jura/correspondances.csv")
+    fieldnames = [
+        "source_uuid",
+        "source_title",
+        "source_name",
+        "target_name",
+        "target_uuid",
+    ]
+    with input_csv.open() as csvfile:
+        reader = csv.DictReader(csvfile, delimiter=";", fieldnames=fieldnames)
+
+        row_num = 0
+        for row in reader:
+            row_num += 1
+            src_uuid = row.get("source_uuid")
+            src_title = row.get("source_title")
+            src_name = row.get("source_name")
+            trg_uuid = row.get("target_uuid")
+            trg_name = row.get("target_name")
+            if src_uuid != "source_uuid":
+                src_found.append(src_uuid)
+                trg_found.append(trg_uuid)
+                # check if the target metadata exists
+                if trg_uuid == "NR":
+                    logger.info("l.{} - there is no target".format(row_num))
+                # check source UUID validity
+                elif not checker.check_is_uuid(src_uuid):
+                    logger.info(
+                        "l.{} - {} source UUID isn't valid".format(row_num, src_uuid)
+                    )
+                # check if source UUID appears just one time in the field
+                elif li_src_to_migrate.count(src_uuid) > 0:
+                    logger.info(
+                        "l.{} - {} already exist in the tab at line {}".format(
+                            row_num, src_uuid, str(src_found.index(src_uuid) + 1)
+                        )
+                    )
+                # if UUID, title and name of source metadata have passed all checks,
+                # time to test UUID and nam of target metadata
+                else:
+                    # check target UUID validity
+                    if not checker.check_is_uuid(trg_uuid):
+                        logger.info(
+                            "l.{} -{} target UUID isn't valid".format(row_num, trg_uuid)
+                        )
+                    # check if target UUID appears just one time in the field
+                    elif li_trg_to_migrate.count(trg_uuid) > 0:
+                        logger.info(
+                            "l.{} - {} target UUID already exist in the tab at line {}".format(
+                                row_num, trg_uuid, str(trg_found.index(trg_uuid) + 1)
+                            )
+                        )
+                    # check if target UUID is different from source UUID
+                    elif trg_uuid == src_uuid:
+                        logger.info(
+                            "l.{} - {} target and source UUID are the same".format(
+                                row_num, trg_uuid
+                            )
+                        )
+                    # if all check are passed, metadata are stored into a tuple that is
+                    # added to a list, plus source and targt UUID are added to the list
+                    # that will be used to backup
+                    else:
+                        to_migrate = (src_uuid, src_title, src_name)
+                        li_src_to_migrate.append(to_migrate)
+                        to_migrate = (trg_uuid, trg_name)
+                        li_trg_to_migrate.append(to_migrate)
+
+                        li_to_backup.extend([src_uuid, trg_uuid])
+            else:
+                pass
+
+    # once each row have been test, a summary of the checks is logged
+    expected_uuid_nb = len(src_found)
+    found_uuid_nbr = len(li_src_to_migrate)
+    if found_uuid_nbr == expected_uuid_nb:
+        logger.info("--> All lines passed the check.")
+    else:
+        logger.info(
+            "--> {}/{} lines didn't passe the check.".format(
+                expected_uuid_nb - found_uuid_nbr, expected_uuid_nb
+            )
+        )
+    if len(set(li_src_to_migrate)) == found_uuid_nbr:
+        logger.info("--> Each source uuid appears only once.")
+    else:
+        logger.info("--> There is some duplicate source uuid.")
+
+    found_uuid_nbr = len(li_trg_to_migrate)
+    if len(set(li_trg_to_migrate)) == found_uuid_nbr:
+        logger.info("--> Each target uuid appears only once.")
+    else:
+        logger.info("--> There is some duplicate target uuid.")
+
+    # ############################### MIGRATING & SAVING ###############################
+    # API client instanciation
+    isogeo = Isogeo(
+        client_id=environ.get("ISOGEO_API_USER_LEGACY_CLIENT_ID"),
+        client_secret=environ.get("ISOGEO_API_USER_LEGACY_CLIENT_SECRET"),
+        auth_mode="user_legacy",
+        auto_refresh_url="{}/oauth/token".format(environ.get("ISOGEO_ID_URL")),
+        platform=environ.get("ISOGEO_PLATFORM", "qa"),
+    )
+    isogeo.connect(
+        username=environ.get("ISOGEO_USER_NAME"),
+        password=environ.get("ISOGEO_USER_PASSWORD"),
+    )
+
+    logger.info(
+        "{} medatatas will be migrated and {} will be saved".format(
+            len(li_src_to_migrate),
+            len(li_to_backup)
+        )
+    )
+
+    # BACKUP
+    backup_mngr = BackupManager(api_client=isogeo, output_folder="./scripts/jura/output")
+    search_parameters = {"query": None, "specific_md": tuple(li_to_backup)}
+    backup_mngr.metadata(search_params=search_parameters)
+
+    # MIGRATING
+    index = 0
+    for md in li_src_to_migrate:
+        logger.info("Migrating metadata {}/{}".format(index + 1, len(li_src_to_migrate)))
+
+        src_uuid = md[0]
+        src_title = md[1]
+        src_name = md[2]
+        trg_uuid = li_trg_to_migrate[index][0]
+
+        # loading the metadata to duplicate from his UUID
+        src_migrator = MetadataDuplicator(
+            api_client=isogeo, source_metadata_uuid=src_uuid
+        )
+        src_loaded = src_migrator.metadata_source
+
+        # check if the metadata exists
+        if isinstance(src_loaded, tuple):
+            logger.info(
+                "{} - There is no accessible source metadata corresponding to this "
+                "uuid".format(src_uuid)
+            )
+            pass
+
+        # checks metadata name and title indicated in the mapping table
+        # then, dupplicate the metadata
+        else:
+            if src_title == src_loaded._title:
+                pass
+            else:
+                logger.info(
+                    "{} - this metadata title is '{}' and not '{}'".format(
+                        src_uuid, src_loaded._title, src_title
+                    )
+                )
+                pass
+
+            if src_name == src_loaded._name:
+                pass
+            else:
+                logger.info(
+                    "{} - this metadata name is '{}' and not '{}'".format(
+                        src_uuid, src_loaded._name, src_name
+                    )
+                )
+                pass
+            li_exclude_fields = [
+                "coordinateSystem",
+                "envelope",
+                "features",
+                "geometry",
+                "name",
+                "path",
+                "format",
+                "formatVersion",
+                "series",
+            ]
+            md_dst = src_migrator.import_into_other_metadata(
+                copymark_abstract=False,  # FALSE EN PROD
+                copymark_title=False,  # FALSE EN PROD
+                destination_metadata_uuid=trg_uuid,
+                exclude_fields=li_exclude_fields,
+            )
+            index += 1
+
+    isogeo.close()

--- a/scripts/jura/migration_jura.py
+++ b/scripts/jura/migration_jura.py
@@ -203,6 +203,7 @@ if __name__ == "__main__":
         li_bound.append(50 * i)
     li_bound.append(len(li_to_backup))
 
+    logger.info("Starting backup for {} rounds".format(len(li_bound) - 1))
     for i in range(len(li_bound) - 1):
         bound_inf = li_bound[i]
         bound_sup = li_bound[i + 1]
@@ -215,6 +216,7 @@ if __name__ == "__main__":
             logger.info("an error occured : {}".format(e))
 
     # MIGRATING
+    logger.info("Starting migration")
     index = 0
     for md in li_src_to_migrate:
         logger.info("Migrating metadata {}/{}".format(index + 1, len(li_src_to_migrate)))
@@ -249,8 +251,6 @@ if __name__ == "__main__":
                         src_uuid, src_loaded._title, src_title
                     )
                 )
-                pass
-
             if src_name == src_loaded._name:
                 pass
             else:
@@ -259,7 +259,6 @@ if __name__ == "__main__":
                         src_uuid, src_loaded._name, src_name
                     )
                 )
-                pass
             li_exclude_fields = [
                 "coordinateSystem",
                 "envelope",

--- a/scripts/jura/migration_jura.py
+++ b/scripts/jura/migration_jura.py
@@ -53,7 +53,7 @@ if __name__ == "__main__":
 
     # debug to the file
     log_file_handler = RotatingFileHandler(
-        Path("./scripts/jura/migration_jura.log"), "a", 5000000, 1
+        Path("./scripts/jura/_logs/migration_jura.log"), "a", 5000000, 1
     )
     log_file_handler.setLevel(logging.INFO)
     log_file_handler.setFormatter(log_format)

--- a/scripts/jura/migration_jura.py
+++ b/scripts/jura/migration_jura.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":
                         to_migrate = (trg_uuid, trg_name)
                         li_trg_to_migrate.append(to_migrate)
 
-                        li_to_backup.extend([src_uuid, trg_uuid])
+                        li_to_backup.append(src_uuid)
             else:
                 pass
 
@@ -194,11 +194,25 @@ if __name__ == "__main__":
             len(li_to_backup)
         )
     )
-
     # BACKUP
     backup_mngr = BackupManager(api_client=isogeo, output_folder="./scripts/jura/output")
-    search_parameters = {"query": None, "specific_md": tuple(li_to_backup)}
-    backup_mngr.metadata(search_params=search_parameters)
+
+    bound_range = int(len(li_to_backup) / 50)
+    li_bound = []
+    for i in range(bound_range + 1):
+        li_bound.append(50 * i)
+    li_bound.append(len(li_to_backup))
+
+    for i in range(len(li_bound) - 1):
+        bound_inf = li_bound[i]
+        bound_sup = li_bound[i + 1]
+        logger.info("Round {} - backup from source metadata {} to {}".format(i, bound_inf + 1, bound_sup))
+
+        search_parameters = {"query": None, "specific_md": tuple(li_to_backup[bound_inf:bound_sup])}
+        try:
+            backup_mngr.metadata(search_params=search_parameters)
+        except Exception as e:
+            logger.info("an error occured : {}".format(e))
 
     # MIGRATING
     index = 0


### PR DESCRIPTION
## Rédiger le script de migration des métadonnées du CD 39

### Trois script ont été développés :
* **`scripts/jura/duplicate_jura.py`** : script permettant de dupliquer des fiches de métadonnées source et cible à partir d'une table de correspondances, dans le groupe de travail "Isogeo Migrations". Lors de la duplication, la table de correspondance des fiches ainsi créée dans "Isogeo Migrations" est générée en `csv` (`sample.csv`). Cela permet de tester le script de migration dans le groupe de travail "Isogeo Migrations" sur un échantillon ou sur l'ensemble des fiches.

* **`scripts/jura/migration_jura.py`** : script de migration des métadonnées du Conseil départemental du Jura. Ce script a été testé dans le groupe de travail "Isogeo Migrations" avant d'être lancé en prod. Au bout d'une quarantaine (ce nombre est variable) de requêtes à l'API Isogeo, une erreur Python liée à la gestion des codes erreur renvoyés par l'API Isogeo par le SDK Python est signalée. Le script passe alors à la fiche suivante. A la fin du script, la table de correspondances des fiches qui n'ont pas pu être migrées est générée en `csv` (`migrate_failed.csv`). Il faut alors relancer le script sur ce fichier.

* **`scripts/jura/delete_jura.py`** : script permettant de supprimer les fiches source une fois que la migration a été effectuée.