### PR TITLE
Improve MetadataDuplicator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,7 +126,7 @@ metadata.json
 *.log.*
 
 # output
-*output/*
+scripts/*/*/_output/*
 *.csv
 !input/sample_migration_import.csv
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,7 @@
         "--ignore=E24,E265,E501,W504",
         "--verbose"
     ],
-    "python.pythonPath": "C:\\Users\\JulienMOURA\\.virtualenvs\\migrations-toolbelt-Ipnv7lTT\\Scripts\\python.exe",
+    "python.pythonPath": ".venv\\Scripts\\python.exe",
     "python.testing.pytestEnabled": true,
     "python.testing.pytestArgs": [
         "-c",

--- a/isogeo_migrations_toolbelt/duplicate/duplicator.py
+++ b/isogeo_migrations_toolbelt/duplicate/duplicator.py
@@ -312,8 +312,6 @@ class MetadataDuplicator(object):
         :param str copymark_catalog: add the new metadata to this additionnal catalog. Defaults to None
         :param bool copymark_title: add a [COPY] mark at the end of the new metadata (default: {True}). Defaults to True
         :param bool copymark_abstract: add a [Copied from](./source_uuid)] mark at the end of the new metadata abstract. Defaults to True
-        :param bool switch_service_layers: a service layer can't be associated to many datasetes. \
-            If this option is enabled, service layers are removed from the metadata source then added to the new one. Defaults to False
 
         :returns: the newly created Metadata
         :rtype: Metadata

--- a/isogeo_migrations_toolbelt/duplicate/duplicator.py
+++ b/isogeo_migrations_toolbelt/duplicate/duplicator.py
@@ -24,7 +24,7 @@ from uuid import UUID
 import urllib3
 
 # Isogeo
-from isogeo_pysdk import Isogeo, IsogeoUtils
+from isogeo_pysdk import Isogeo
 from isogeo_pysdk.checker import IsogeoChecker
 from isogeo_pysdk.models import (
     Catalog,
@@ -32,7 +32,6 @@ from isogeo_pysdk.models import (
     Contact,
     CoordinateSystem,
     Event,
-    License,
     Limitation,
     Link,
     Metadata,

--- a/isogeo_migrations_toolbelt/duplicate/duplicator.py
+++ b/isogeo_migrations_toolbelt/duplicate/duplicator.py
@@ -303,6 +303,7 @@ class MetadataDuplicator(object):
     def duplicate_into_other_group(
         self,
         destination_workgroup_uuid: str,
+        copymark_catalog: str = None,
         copymark_title: bool = True,
         copymark_abstract: bool = True,
     ) -> Metadata:
@@ -400,6 +401,9 @@ class MetadataDuplicator(object):
         li_catalogs_uuids = {
             tag[8:] for tag in self.metadata_source.tags if tag.startswith("catalog:")
         }
+
+        if copymark_catalog is not None:
+            li_catalogs_uuids.append(copymark_catalog)
 
         if len(li_catalogs_uuids):
             # retrieve catalogs fo the destination group to match with source

--- a/isogeo_migrations_toolbelt/duplicate/duplicator.py
+++ b/isogeo_migrations_toolbelt/duplicate/duplicator.py
@@ -85,6 +85,7 @@ class MetadataDuplicator(object):
         copymark_catalog: str = None,
         copymark_title: bool = True,
         copymark_abstract: bool = True,
+        exclude_catalogs: list = [],
         switch_service_layers: bool = False,
     ) -> Metadata:
         """Create an exact copy of the metadata source in the same workgroup.
@@ -93,6 +94,7 @@ class MetadataDuplicator(object):
         :param str copymark_catalog: add the new metadata to this additionnal catalog. Defaults to None
         :param bool copymark_title: add a [COPY] mark at the end of the new metadata (default: {True}). Defaults to True
         :param bool copymark_abstract: add a [Copied from](./source_uuid)] mark at the end of the new metadata abstract. Defaults to True
+        :param list exclude_catalogs: list of catalogs UUID's to not associate to destination metadata
         :param bool switch_service_layers: a service layer can't be associated to many datasetes. \
             If this option is enabled, service layers are removed from the metadata source then added to the new one. Defaults to False
 
@@ -151,7 +153,7 @@ class MetadataDuplicator(object):
         # NOW PERFORM DUPLICATION OF SUBRESOURCES
         # Catalogs
         li_catalogs_uuids = [
-            tag[8:] for tag in self.metadata_source.tags if tag.startswith("catalog:")
+            tag[8:] for tag in self.metadata_source.tags if tag.startswith("catalog:") and tag[8:] not in exclude_catalogs
         ]
         if copymark_catalog is not None:
             li_catalogs_uuids.append(copymark_catalog)
@@ -306,6 +308,7 @@ class MetadataDuplicator(object):
         copymark_catalog: str = None,
         copymark_title: bool = True,
         copymark_abstract: bool = True,
+        exclude_catalogs: list = []
     ) -> Metadata:
         """Create an exact copy of the metadata source into another workgroup.
         It can apply some copy marks to distinguish the copy from the original.
@@ -313,6 +316,7 @@ class MetadataDuplicator(object):
         :param str copymark_catalog: add the new metadata to this additionnal catalog. Defaults to None
         :param bool copymark_title: add a [COPY] mark at the end of the new metadata (default: {True}). Defaults to True
         :param bool copymark_abstract: add a [Copied from](./source_uuid)] mark at the end of the new metadata abstract. Defaults to True
+        :param list exclude_catalogs: list of catalogs UUID's to not associate to destination metadata
 
         :returns: the newly created Metadata
         :rtype: Metadata
@@ -398,9 +402,9 @@ class MetadataDuplicator(object):
 
         # list and cache catalogs in the destination workgroup
         # parse source metadata catalogs
-        li_catalogs_uuids = {
-            tag[8:] for tag in self.metadata_source.tags if tag.startswith("catalog:")
-        }
+        li_catalogs_uuids = [
+            tag[8:] for tag in self.metadata_source.tags if tag.startswith("catalog:") and tag[8:] not in exclude_catalogs
+        ]
 
         if copymark_catalog is not None:
             li_catalogs_uuids.append(copymark_catalog)
@@ -410,7 +414,6 @@ class MetadataDuplicator(object):
             self.isogeo.catalog.listing(
                 workgroup_id=destination_workgroup_uuid, include=(), caching=1
             )
-
             for cat_uuid in li_catalogs_uuids:
                 # retrieve online catalog
                 src_catalog = self.isogeo.catalog.get(
@@ -612,6 +615,7 @@ class MetadataDuplicator(object):
         copymark_catalog: str = None,
         copymark_title: bool = True,
         copymark_abstract: bool = True,
+        exclude_catalogs: list = [],
         switch_service_layers: bool = False,
         exclude_fields: list = [
             "coordinateSystem",
@@ -630,6 +634,7 @@ class MetadataDuplicator(object):
         :param str copymark_catalog: add the new metadata to this additionnal catalog. Defaults to None
         :param bool copymark_title: add a [COPY] mark at the end of the new metadata (default: {True}). Defaults to True
         :param bool copymark_abstract: add a [Copied from](./source_uuid)] mark at the end of the new metadata abstract. Defaults to True
+        :param list exclude_catalogs: list of catalogs UUID's to not associate to destination metadata
         :param bool switch_service_layers: a service layer can't be associated to many datasetes. \
             If this option is enabled, service layers are removed from the metadata source then added to the new one. Defaults to False
 
@@ -706,7 +711,7 @@ class MetadataDuplicator(object):
         # NOW PERFORM DUPLICATION OF SUBRESOURCES
         # Catalogs
         li_catalogs_uuids = [
-            tag[8:] for tag in md_src.tags if tag.startswith("catalog:")
+            tag[8:] for tag in md_src.tags if tag.startswith("catalog:") and tag[8:] not in exclude_catalogs
         ]
         if copymark_catalog is not None:
             li_catalogs_uuids.append(copymark_catalog)


### PR DESCRIPTION
**Improve catalogs management by:**
* adding the possibility to not associate source catalogs to target ( close #9 )
* adding the 'copymark_catalog' option to *import_into_other_group(...)* method ( close #25 )
